### PR TITLE
Enable SourceMaps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     filename: "index.js",
     libraryTarget: "commonjs2"
   },
-  devtool: "none",
+  devtool: "eval-source-map",
   plugins: [
     new webpack.DefinePlugin({
       MAGIC_CONSTANT: JSON.stringify("some_thing")


### PR DESCRIPTION
took me a while to figure out which flavours of source maps work here
(inline does not.)

Or was there a deeper reason why this had been set to none?